### PR TITLE
タイピング完了時の処理を作成する

### DIFF
--- a/backend/app/controllers/api/file_items_controller.rb
+++ b/backend/app/controllers/api/file_items_controller.rb
@@ -13,12 +13,14 @@ module Api
     def update
       repository = @current_user.repositories.find(params[:repository_id])
       file_item = repository.file_items.find(params[:id])
-      if file_item.update_with_parent(file_item_params)
+      if file_item.update_with_parent(file_item_params) && repository.update(last_typed_at: Time.zone.now)
         top_level_file_items = repository.file_items.roots
         render json: FileItemSerializer.new(top_level_file_items, params: { children: true }), status: :ok
       else
-        render json: { error: 'ファイルの更新に失敗しました。' }, status: :unprocessable_entity
+        render json: file_item.errors, status: :unprocessable_entity
       end
+    rescue StandardError
+      render json: { error: 'ファイルの更新に失敗しました。' }, status: :internal_server_error
     end
 
     private

--- a/backend/app/controllers/api/file_items_controller.rb
+++ b/backend/app/controllers/api/file_items_controller.rb
@@ -9,5 +9,22 @@ module Api
     rescue ActiveRecord::RecordNotFound
       render json: { error: 'ファイルが存在しません。' }, status: :not_found
     end
+
+    def update
+      repository = @current_user.repositories.find(params[:repository_id])
+      file_item = repository.file_items.find(params[:id])
+      if file_item.update_with_parent(file_item_params)
+        top_level_file_items = repository.file_items.roots
+        render json: FileItemSerializer.new(top_level_file_items, params: { children: true }), status: :ok
+      else
+        render json: { error: 'ファイルの更新に失敗しました。' }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def file_item_params
+      params.expect(file_item: [:status])
+    end
   end
 end

--- a/backend/app/models/file_item.rb
+++ b/backend/app/models/file_item.rb
@@ -47,6 +47,6 @@ class FileItem < ApplicationRecord
     is_all_typed = children.all?(&:typed?)
     return true unless is_all_typed
 
-    parent.update(status: :typed) && parent.update_parent_status
+    parent.update!(status: :typed) && parent.update_parent_status
   end
 end

--- a/backend/app/models/file_item.rb
+++ b/backend/app/models/file_item.rb
@@ -33,4 +33,20 @@ class FileItem < ApplicationRecord
 
     "#{repository.name}/#{path}"
   end
+
+  def update_with_parent(params)
+    transaction do
+      update(params) && update_parent_status
+    end
+  end
+
+  def update_parent_status
+    return true unless parent
+
+    children = parent.children
+    is_all_typed = children.all?(&:typed?)
+    return true unless is_all_typed
+
+    parent.update(status: :typed) && parent.update_parent_status
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :repositories, only: [:index, :show, :create] do
-      resources :file_items, only: [:show]
+      resources :file_items, only: [:show, :update]
     end
   end
 end

--- a/backend/spec/models/file_item_spec.rb
+++ b/backend/spec/models/file_item_spec.rb
@@ -13,4 +13,114 @@ RSpec.describe FileItem, type: :model do
       expect(file_item.full_path).to eq('test_repo/root_dir/middle_dir/test_file.rb')
     end
   end
+
+  describe '#update_with_parent' do
+    let(:repository) { create(:repository) }
+    let(:parent_dir) { create(:file_item, :directory, repository: repository) }
+    let(:untyped_file_item) { create(:file_item, repository: repository, parent: parent_dir) }
+
+    context 'when all siblings are typed after update' do
+      before do
+        create(:file_item, :typed, repository: repository, parent: parent_dir)
+      end
+
+      it 'returns true' do
+        expect(untyped_file_item.update_with_parent(status: :typed)).to be true
+      end
+
+      it 'updates both file item and parent status' do
+        untyped_file_item.update_with_parent(status: :typed)
+
+        expect(untyped_file_item.reload.status).to eq('typed')
+        expect(parent_dir.reload.status).to eq('typed')
+      end
+    end
+
+    context 'when not all siblings are typed after update' do
+      before do
+        create(:file_item, repository: repository, parent: parent_dir)
+      end
+
+      it 'returns true' do
+        expect(untyped_file_item.update_with_parent(status: :typed)).to be true
+      end
+
+      it 'updates only the file item status but not parent status' do
+        untyped_file_item.update_with_parent(status: :typed)
+
+        expect(untyped_file_item.reload.status).to eq('typed')
+        expect(parent_dir.reload.status).to eq('untyped')
+      end
+    end
+
+    context 'when update failed' do
+      before do
+        allow(untyped_file_item).to receive(:update).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(untyped_file_item.update_with_parent(status: :typed)).to be false
+      end
+
+      it 'does not update both file item and parent status' do
+        untyped_file_item.update_with_parent(status: :typed)
+
+        expect(untyped_file_item.reload.status).to eq('untyped')
+        expect(parent_dir.reload.status).to eq('untyped')
+      end
+    end
+
+    context 'when update_parent_status failed' do
+      before do
+        allow(untyped_file_item).to receive(:update_parent_status).and_raise(ActiveRecord::Rollback)
+      end
+
+      it 'returns nil' do
+        expect(untyped_file_item.update_with_parent(status: :typed)).to be_nil
+      end
+
+      it 'does not update both file item and parent status' do
+        untyped_file_item.update_with_parent(status: :typed)
+
+        expect(untyped_file_item.reload.status).to eq('untyped')
+        expect(parent_dir.reload.status).to eq('untyped')
+      end
+    end
+  end
+
+  describe '#update_parent_status' do
+    let(:repository) { create(:repository) }
+    let(:parent_dir) { create(:file_item, :directory, repository: repository, status: :untyped) }
+    let(:typed_file_item) { create(:file_item, :typed, repository: repository, parent: parent_dir) }
+
+    context 'when all siblings are typed' do
+      it 'updates parent status to typed' do
+        create(:file_item, :typed, repository: repository, parent: parent_dir)
+
+        expect(typed_file_item.update_parent_status).to be true
+        expect(parent_dir.reload.status).to eq('typed')
+      end
+    end
+
+    context 'when not all siblings are typed' do
+      it 'does not update parent status' do
+        create(:file_item, repository: repository, parent: parent_dir)
+
+        expect(typed_file_item.update_parent_status).to be true
+        expect(parent_dir.reload.status).to eq('untyped')
+      end
+    end
+
+    context 'with all descendants are typed' do
+      it 'recursively updates all parents when all children are typed' do
+        root_dir = create(:file_item, :directory, repository: repository)
+        child_dir = create(:file_item, :directory, repository: repository, parent: root_dir)
+        grand_child_file_item = create(:file_item, :typed, repository: repository, parent: child_dir)
+
+        expect(grand_child_file_item.update_parent_status).to be true
+        expect(root_dir.reload.status).to eq('typed')
+        expect(child_dir.reload.status).to eq('typed')
+      end
+    end
+  end
 end

--- a/backend/spec/requests/api/file_items_spec.rb
+++ b/backend/spec/requests/api/file_items_spec.rb
@@ -30,4 +30,56 @@ RSpec.describe 'Api::FileItems', type: :request do
       end
     end
   end
+
+  describe 'PATCH /api/repositories/:repository_id/file_items/:id' do
+    let(:untyped_file_item) { repository.file_items.where(type: :file, status: :untyped).first }
+
+    context 'when update successfully' do
+      it 'returns success status' do
+        patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
+              params: { file_item: { status: :typed } }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the file item and returns success status' do
+        patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
+              params: { file_item: { status: :typed } }, headers: headers
+
+        json = response.parsed_body
+        updated_file_item = json.find { |item| item['id'] == untyped_file_item.id }
+        expect(updated_file_item['status']).to eq('typed')
+      end
+
+      it 'returns all file items' do
+        patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
+              params: { file_item: { status: :typed } }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json.length).to eq(4)
+        expect(json.first['file_items'].length).to eq(2)
+      end
+    end
+
+    context 'when update failed' do
+      it 'returns unprocessable entity status' do
+        patch api_repository_file_item_path(repository_id: repository.id, id: file_item.id),
+              params: { file_item: { status: '' } }, headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = response.parsed_body
+        expect(json['status']).to eq(['can\'t be blank'])
+      end
+    end
+
+    context 'when unexpected error occurs' do
+      it 'returns internal server error status' do
+        patch api_repository_file_item_path(repository_id: repository.id, id: file_item.id),
+              params: { file_item: { status: :invalid } }, headers: headers
+
+        expect(response).to have_http_status(:internal_server_error)
+      end
+    end
+  end
 end

--- a/backend/spec/requests/api/file_items_spec.rb
+++ b/backend/spec/requests/api/file_items_spec.rb
@@ -35,26 +35,22 @@ RSpec.describe 'Api::FileItems', type: :request do
     let(:untyped_file_item) { repository.file_items.where(type: :file, status: :untyped).first }
 
     context 'when update successfully' do
-      it 'returns success status' do
+      before do
         patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
               params: { file_item: { status: :typed } }, headers: headers
+      end
 
+      it 'returns success status' do
         expect(response).to have_http_status(:ok)
       end
 
       it 'updates the file item and returns success status' do
-        patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
-              params: { file_item: { status: :typed } }, headers: headers
-
         json = response.parsed_body
         updated_file_item = json.find { |item| item['id'] == untyped_file_item.id }
         expect(updated_file_item['status']).to eq('typed')
       end
 
       it 'returns all file items' do
-        patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
-              params: { file_item: { status: :typed } }, headers: headers
-
         expect(response).to have_http_status(:ok)
         json = response.parsed_body
         expect(json.length).to eq(4)

--- a/frontend/__tests__/app/repositories/[id]/page.test.tsx
+++ b/frontend/__tests__/app/repositories/[id]/page.test.tsx
@@ -257,6 +257,42 @@ describe('RepositoryDetailPage', () => {
     });
 
     it('render result when type all characters', async () => {
+      const mockFileItems = [
+        {
+          id: 1,
+          name: 'file1.ts',
+          type: 'file',
+          status: 'untyped',
+          fileItems: [],
+        },
+        {
+          id: 2,
+          name: 'file2.ts',
+          type: 'file',
+          status: 'typed',
+          fileItems: [],
+        },
+        {
+          id: 3,
+          name: 'dir1',
+          type: 'dir',
+          status: 'untyped',
+          fileItems: [
+            {
+              id: 4,
+              name: 'nested-file1.ts',
+              type: 'file',
+              status: 'typed',
+              fileItems: [],
+            },
+          ],
+        },
+      ];
+
+      jest.spyOn(axios, 'patch').mockImplementation(() => {
+        return Promise.resolve(mockFileItems);
+      });
+
       await userEvent.keyboard('console.log("Hello, world!");');
 
       expect(screen.getByText('Completed!!')).toBeInTheDocument(); // TODO: 完了画面を作ったら修正する

--- a/frontend/src/app/repositories/[id]/page.tsx
+++ b/frontend/src/app/repositories/[id]/page.tsx
@@ -27,5 +27,5 @@ export default async function RepositoryDetailPage({ params }: RepositoryDetailP
   const fileItems: FileItem[] | [] = repository.fileItems;
   const sortedFileItems = sortFileItems(fileItems);
 
-  return <RepositoryDetail fileItems={sortedFileItems} />;
+  return <RepositoryDetail initialFileItems={sortedFileItems} />;
 }

--- a/frontend/src/components/repositories/FileItemView.tsx
+++ b/frontend/src/components/repositories/FileItemView.tsx
@@ -11,11 +11,12 @@ import { TypingPanel } from './TypingPanel';
 
 type FileItemViewProps = {
   fileItem: FileItem | null;
+  setFileItems: (fileItems: FileItem[]) => void;
   typingStatus: TypingStatus;
   setTypingStatus: (status: TypingStatus) => void;
 };
 
-export function FileItemView({ fileItem, typingStatus, setTypingStatus }: FileItemViewProps) {
+export function FileItemView({ fileItem, setFileItems, typingStatus, setTypingStatus }: FileItemViewProps) {
   const params = useParams();
   const url = fileItem ? `/api/repositories/${params.id}/file_items/${fileItem.id}` : null;
   const { data: session } = useSession();
@@ -40,6 +41,7 @@ export function FileItemView({ fileItem, typingStatus, setTypingStatus }: FileIt
         ) : (
           <TypingPanel
             fileItem={fileItemData as FileItem}
+            setFileItems={setFileItems}
             typingStatus={typingStatus}
             setTypingStatus={setTypingStatus}
           />

--- a/frontend/src/components/repositories/RepositoryDetail.tsx
+++ b/frontend/src/components/repositories/RepositoryDetail.tsx
@@ -6,7 +6,12 @@ import { FileItem, TypingStatus } from '@/types';
 import { FileItemView } from './FileItemView';
 import { FileTree } from './FileTree';
 
-export function RepositoryDetail({ fileItems }: { fileItems: FileItem[] }) {
+type RepositoryDetailProps = {
+  initialFileItems: FileItem[];
+};
+
+export function RepositoryDetail({ initialFileItems }: RepositoryDetailProps) {
+  const [fileItems, setFileItems] = useState<FileItem[]>(initialFileItems);
   const [selectedFileItem, setSelectedFileItem] = useState<FileItem | null>(null);
   const [typingStatus, setTypingStatus] = useState<TypingStatus>('ready');
 
@@ -17,7 +22,6 @@ export function RepositoryDetail({ fileItems }: { fileItems: FileItem[] }) {
         return;
       }
     }
-
     setSelectedFileItem(fileItem);
     setTypingStatus('ready');
   };
@@ -30,7 +34,12 @@ export function RepositoryDetail({ fileItems }: { fileItems: FileItem[] }) {
         </div>
 
         <div className="flex-1 overflow-y-auto">
-          <FileItemView fileItem={selectedFileItem} typingStatus={typingStatus} setTypingStatus={setTypingStatus} />
+          <FileItemView
+            fileItem={selectedFileItem}
+            setFileItems={setFileItems}
+            typingStatus={typingStatus}
+            setTypingStatus={setTypingStatus}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/components/repositories/TypingContent.tsx
+++ b/frontend/src/components/repositories/TypingContent.tsx
@@ -8,6 +8,7 @@ type TypingContentProps = {
   cursorLine: number;
   cursorPositions: number[];
   typingStatus: TypingStatus;
+  errorMessage: string | null;
 };
 
 export function TypingContent({
@@ -17,31 +18,38 @@ export function TypingContent({
   cursorLine,
   cursorPositions,
   typingStatus,
+  errorMessage,
 }: TypingContentProps) {
   return (
     <div className="overflow-x-auto px-4">
-      {typingStatus === 'ready' ? (
-        <pre className="font-mono">
-          {content.split('\n').map((line, i) => (
-            <p key={i} className="h-[1.4em]">
-              {line}
-            </p>
-          ))}
-        </pre>
-      ) : typingStatus === 'typing' || typingStatus === 'paused' ? (
-        <div>
-          {targetTextLines.map((targetTextLine, index) => (
-            <TypingLine
-              key={index}
-              typedText={typedTextLines[index]}
-              targetTextLine={targetTextLine}
-              cursorPosition={cursorPositions[index]}
-              isUntypedLine={index > cursorLine}
-            />
-          ))}
-        </div>
+      {errorMessage ? (
+        <div className="p-6 text-center font-mono text-gray-500">{errorMessage}</div>
       ) : (
-        <div className="h-[1.4em]">Completed!!</div>
+        <>
+          {typingStatus === 'ready' ? (
+            <pre className="font-mono">
+              {content.split('\n').map((line, i) => (
+                <p key={i} className="h-[1.4em]">
+                  {line}
+                </p>
+              ))}
+            </pre>
+          ) : typingStatus === 'typing' || typingStatus === 'paused' ? (
+            <div>
+              {targetTextLines.map((targetTextLine, index) => (
+                <TypingLine
+                  key={index}
+                  typedText={typedTextLines[index]}
+                  targetTextLine={targetTextLine}
+                  cursorPosition={cursorPositions[index]}
+                  isUntypedLine={index > cursorLine}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="h-[1.4em]">Completed!!</div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/repositories/TypingPanel.tsx
+++ b/frontend/src/components/repositories/TypingPanel.tsx
@@ -5,18 +5,29 @@ import { TypingHeader } from './TypingHeader';
 
 type TypingPanelProps = {
   fileItem: FileItem;
+  setFileItems: (fileItems: FileItem[]) => void;
   typingStatus: TypingStatus;
   setTypingStatus: (status: TypingStatus) => void;
 };
 
-export function TypingPanel({ fileItem, typingStatus, setTypingStatus }: TypingPanelProps) {
+export function TypingPanel({ fileItem, setFileItems, typingStatus, setTypingStatus }: TypingPanelProps) {
   const targetTextLines = fileItem?.content?.split(/(?<=\n)/) || [];
-  const { typedTextLines, cursorPositions, cursorLine, startTyping, resetTyping, pauseTyping, resumeTyping } =
-    useTypingHandler({
-      targetTextLines,
-      typingStatus,
-      setTypingStatus,
-    });
+  const {
+    typedTextLines,
+    cursorPositions,
+    cursorLine,
+    errorMessage,
+    startTyping,
+    resetTyping,
+    pauseTyping,
+    resumeTyping,
+  } = useTypingHandler({
+    targetTextLines,
+    fileItemId: fileItem.id,
+    setFileItems,
+    typingStatus,
+    setTypingStatus,
+  });
   return (
     <>
       <TypingHeader
@@ -34,6 +45,7 @@ export function TypingPanel({ fileItem, typingStatus, setTypingStatus }: TypingP
         cursorLine={cursorLine}
         cursorPositions={cursorPositions}
         typingStatus={typingStatus}
+        errorMessage={errorMessage}
       />
     </>
   );

--- a/frontend/src/components/repositories/TypingResult.tsx
+++ b/frontend/src/components/repositories/TypingResult.tsx
@@ -1,0 +1,3 @@
+export function TypingResult() {
+  return <div>TypingResult</div>;
+}

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -21,3 +21,13 @@ export async function axiosPost<P>(url: string, accessToken: string | undefined,
 
   return await axios.post(`${BASE_URL}${url}`, params, { headers });
 }
+
+export async function axiosPatch<P>(url: string, accessToken: string | undefined, params: P) {
+  axiosCaseConverter(axios);
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+  };
+
+  return await axios.patch(`${BASE_URL}${url}`, params, { headers });
+}


### PR DESCRIPTION
# issue

- #91 

# description
以下2点を実装した。
- バックエンドでタイピングしたファイルとその親ディレクトリのステータスを更新する
- ファイルツリーの表示を更新する
